### PR TITLE
Fix #14: Voeg test bestanden toe aan .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.sass-cache
 /node_modules
+/sass/test.css
+/sass/test.scss


### PR DESCRIPTION
Tijdens de ontwikkelen en of verbetering van de `scss` bestanden heb ik de volgende test bestanden voor bepaalde dingen. 
- `sass/test.css`
- `sass/test.scss`

Het is aangeraden om deze toe te voegen in de `.gitignore` file in de repo. Zodat deze per ongeluk niet bij in een commit geraken.
